### PR TITLE
Tweaked npm install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When used in [gatsby-starter-bootstrap-cv](https://github.com/mhjadav/gatsby-sta
 ## Installation
 
 ```sh
-npm i gatsby-plugin-purgecss
+npm install --save gatsby-plugin-purgecss
 ```
 
 ### Usage


### PR DESCRIPTION
Added `--save` to `npm install` command in README. Persists module to `package.json` for users following the docs and is more inline with other Gatsby plugin README's